### PR TITLE
Add sbt-missinglink runtime linkage check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,38 @@ jobs:
 
       - run: scala-steward validate-repo-config .scala-steward.conf
 
+  missinglink:
+    name: Missinglink
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        java: [temurin@17]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Check for missing runtime links
+        run: sbt missinglinkCheck
+
   deploy:
     name: Deploy app
     needs: [build]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,7 @@ pull_request_rules:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
   - status-success=Test (ubuntu-22.04, 3, temurin@17)
+  - status-success=Missinglink (ubuntu-22.04, temurin@17)
   actions:
     merge: {}
 - name: Label api3 PRs

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,85 @@ ThisBuild / tlCiDocCheck := false
 ThisBuild / tlCiReleaseBranches := Seq()
 ThisBuild / tlCiReleaseTags := false
 
+// Shared by the missinglink CI job and the mergify condition that gates on it.
+val missinglinkOs = "ubuntu-22.04"
+val missinglinkJava = JavaSpec.temurin("17")
+
 ThisBuild / mergifyStewardConfig ~= (_.map(_.withMergeMinors(true)))
-// No explicit mergifySuccessConditions: the default derives them from the
-// generated CI matrix, so the required checks track the workflow automatically
-// (the old hardcoded "Build and Test" no longer matches any job name).
+// The default conditions derive from the generated CI matrix, so the required
+// checks track the workflow automatically -- but only for the build job, not
+// for jobs added via githubWorkflowAddedJobs. Append missinglink explicitly: a
+// dependency bump is exactly how a runtime linkage break gets in (see the
+// jsoniter-scala-core fallout from the 0.19.9 bump), and that's invisible to
+// compile+test, so steward shouldn't auto-merge without it.
+//
+// The name must be the *check* name, which GitHub suffixes with the job's
+// matrix ("Missinglink (ubuntu-22.04, temurin@17)"), not the bare job name --
+// a bare "status-success=Missinglink" matches nothing and blocks the merge
+// forever. Built from the same values as the job below so the two can't drift.
+ThisBuild / mergifySuccessConditions += MergifyCondition.Custom(
+  s"status-success=Missinglink ($missinglinkOs, ${missinglinkJava.render})"
+)
+
+// sbt-missinglink checks that everything we call actually exists in the jars we
+// resolve at runtime -- the class of bug that only shows up as a
+// NoClassDefFoundError/NoSuchMethodError on the first request that hits the
+// affected code path.
+//
+// It reads JVM bytecode, so it's only meaningful on JVM projects. On Scala.js
+// ones its "classpath" is the sjs artifacts, where scala-java-time and
+// scala-java-locales are *reimplementations* of java.time/java.util: missinglink
+// compares them against each other rather than against the JDK and reports
+// java.time.ZoneOffset.UTC and friends as missing fields. All noise, so the
+// check is off there.
+lazy val missinglinkSettings = Def.settings(
+  missinglinkIgnoreDestinationPackages ++= List(
+    // fs2-io's optional unix-socket support via jnr, which we don't ship.
+    IgnoredPackage("jnr.unixsocket"),
+    // smithy4s-core ships a near-empty `alloy.openapi` package object that
+    // shadows the real one in alloy-openapi; smithy4s-core comes first on our
+    // classpath, so every alloy.openapi method looks absent. This is a known
+    // upstream bug, not a false positive:
+    // https://github.com/disneystreaming/smithy4s/issues/1860
+    //
+    // It's harmless for us: it only breaks
+    // CodegenImpl.generate(CodegenArgs), the CLI entry point that renders
+    // OpenAPI. We go through the generate(Model, List[String]) overload (see
+    // CodegenTrick), which never touches alloy-openapi -- verified by running
+    // codegen end to end. If we ever call the CodegenArgs overload, the fix is
+    // the upstream workaround: put alloy-openapi first on the classpath.
+    IgnoredPackage("alloy.openapi")
+  )
+)
+
+lazy val noMissinglink = Def.settings(
+  missinglinkCheck := {}
+)
+
+// Its own job so it runs in parallel with the main build: it needs a full
+// compile, so it's too slow to bolt onto the critical path, and it doesn't
+// depend on anything the build job produces.
+ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
+  id = "missinglink",
+  name = "Missinglink",
+  oses = List(missinglinkOs),
+  scalas = Nil,
+  // Must match the java the generated Setup-Java step guards on: that step
+  // renders `if: matrix.java == 'temurin@17'`, which is never true without a
+  // java axis on this job's matrix.
+  javas = List(missinglinkJava),
+  steps = List(
+    WorkflowStep.CheckoutFull,
+    WorkflowStep.SetupSbt
+  ) ::: WorkflowStep.SetupJava(List(missinglinkJava)) ::: List(
+    // A plain Run, not WorkflowStep.Sbt: with `scalas = Nil` the latter renders
+    // `sbt '++ ${{ matrix.scala }}'` with an empty version.
+    WorkflowStep.Run(
+      List("sbt missinglinkCheck"),
+      name = Some("Check for missing runtime links")
+    )
+  )
+)
 
 val http4sVersion = "0.23.36"
 val smithyVersion = "1.72.1"
@@ -143,12 +218,13 @@ lazy val api = (projectMatrix in file("modules/api"))
       "com.disneystreaming.smithy4s" %%% "smithy4s-core" % smithy4sVersion.value
     )
   )
-  .jvmPlatform(Seq(scala3))
-  .jsPlatform(Seq(scala3))
+  .jvmPlatform(Seq(scala3), missinglinkSettings)
+  .jsPlatform(Seq(scala3), noMissinglink)
 
 lazy val frontend = (project in file("modules/frontend"))
   .enablePlugins(ScalaJSPlugin, BuildInfoPlugin)
   .dependsOn(api.js(scala3))
+  .settings(noMissinglink)
   .settings(
     name := "smithy4s-code-generation-frontend",
     cleanFiles ++= {
@@ -271,6 +347,7 @@ lazy val backend = (project in file("modules/backend"))
     DockerPlugin
   )
   .settings(smithyClasspathSettings)
+  .settings(missinglinkSettings)
   .settings(
     name := "smithy4s-code-generation-backend",
     fork := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.8.7")
 addSbtPlugin("org.typelevel" % "sbt-typelevel-mergify" % "0.8.7")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % "0.3.8")


### PR DESCRIPTION
Catches methods/classes that compile fine against one version of a dependency but are absent from the jar we actually resolve at runtime — the failure mode behind the recent jsoniter-scala-core breakage, which compiled and tested green and only blew up as a `NoClassDefFoundError` on the first request through `SimpleRestJsonBuilder`.

Added to the generated workflow via `githubWorkflowAddedJobs`, so it runs in parallel with the main build: it needs a full compile, so it's too slow to bolt onto the critical path, and it doesn't depend on anything the build job produces. Takes ~1m40s, well under the Test job, so it adds no wall-clock time to CI.

## Scope

Only enabled on the JVM projects (`backend`, `apiJVM`). missinglink reads JVM bytecode, so on Scala.js it compares scala-java-time / scala-java-locales — which are *reimplementations* of `java.time`/`java.util` — against each other rather than the JDK, reporting `java.time.ZoneOffset.UTC` and friends as missing fields. All noise, hence `noMissinglink` there.

## Ignored packages

Both suppressed by the missing *target* package rather than by excluding whole jars, so each jar stays fully checked except for calls into the specific absent library:

- **`jnr.unixsocket`** — fs2-io's optional unix-socket support, which we don't ship.
- **`alloy.openapi`** — smithy4s-core ships a near-empty `alloy.openapi` package object that shadows the real one in alloy-openapi, which comes later on our classpath. This is a genuine upstream bug ([disneystreaming/smithy4s#1860](https://github.com/disneystreaming/smithy4s/issues/1860)), not a false positive — but it's harmless here: it only affects `CodegenImpl.generate(CodegenArgs)`, the CLI entry point that renders OpenAPI. We go through the `generate(Model, List[String])` overload via `CodegenTrick`, verified by running codegen end to end against the real runtime classpath.

## Mergify

The derived default only covers the build matrix, not jobs added via `githubWorkflowAddedJobs`, so the new job is appended to `mergifySuccessConditions` explicitly — a dependency bump is precisely how this class of break gets in.

The condition has to be the *check* name, which GitHub suffixes with the job matrix (`Missinglink (ubuntu-22.04, temurin@17)`), not the bare job name — a bare `status-success=Missinglink` matches nothing and would block steward's auto-merge forever. Verified the generated condition is an exact match against the check names GitHub actually reported on this PR. Both the condition and the job are built from the same `missinglinkOs`/`missinglinkJava` vals so they can't drift.

## Verification

The check still fails on a real break: compiling a call against a stub jar that declares a method, then swapping in a variant without it, fails the build with exactly that one conflict while the 39 known-benign ones stay filtered. So the ignore list suppresses noise without blinding the check.

`sbt missinglinkCheck`, `githubWorkflowCheck`, `mergifyCheck` and the scalafmt checks are all green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)