### PR TITLE
Run the deploy job concurrently with build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
 
   deploy:
     name: Deploy app
-    needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     strategy:
       matrix:

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,10 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
   id = "deploy",
   name = "Deploy app",
   cond = Some("github.ref == 'refs/heads/main' && github.event_name == 'push'"),
-  needs = List("build"),
+  // Run concurrently with the build job rather than after it (the default
+  // `needs` is List("build")). The changes were already tested on the PR, so
+  // gating on a second full test run only delays the deploy.
+  needs = Nil,
   oses = List("ubuntu-22.04"),
   scalas = Nil,
   // Must match the java the generated Setup-Java step guards on: that step


### PR DESCRIPTION
Follow-up to #120.

The migration gave the deploy job `needs: [build]`, which serialized it behind the test job. The previous hand-written workflow ran the two concurrently.

On the merge of #120 this cost about 3m17s — `Test` finished at 23:56:07 and `Deploy app` started at 23:56:10. The changes have already been tested on the PR by the time they reach main, so gating the deploy on a second full test run only delays it.

One subtlety: `needs` defaults to `List("build")` in sbt-typelevel, so this passes `Nil` explicitly rather than just dropping the argument.

The generated diff is a single line:

```diff
   deploy:
     name: Deploy app
-    needs: [build]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
```

## Testing

`githubWorkflowCheck`, `mergifyCheck` and `scalafmtSbtCheck` pass. The concurrency change itself only takes effect on a push to main, so it's verified there after merge.